### PR TITLE
multi-stage

### DIFF
--- a/anilist/Dockerfile
+++ b/anilist/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/anilist-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/anilist-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/anilist.jar /app/anilist.jar
+ENTRYPOINT ["java","-jar","/app/anilist.jar"]

--- a/anilist/pom.xml
+++ b/anilist/pom.xml
@@ -85,6 +85,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>anilist</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/discovery-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/discovery-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/discovery.jar /app/discovery.jar
+ENTRYPOINT ["java","-jar","/app/discovery.jar"]

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -42,6 +42,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>discovery</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,22 +1,35 @@
 services:
+  library:
+    image: lampirg/library:0.0.1
+    build:
+      context: library
+      target: build
   discovery:
+    image: lampirg/discovery:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: discovery
+    build:
+      context: discovery
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
     ports:
       - "8761:8080"
   recommendator:
+    image: lampirg/recommendator:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: recommendator
+    build:
+      context: recommendator
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
       EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE: http://discovery:8080/eureka/
@@ -26,12 +39,16 @@ services:
       discovery:
         condition: service_healthy
   mal:
+    image: lampirg/mal:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: mal
+    build:
+      context: mal
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
       EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE: http://discovery:8080/eureka/
@@ -43,12 +60,16 @@ services:
       recommendator:
         condition: service_healthy
   shikimori:
+    image: lampirg/shikimori:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: shikimori
+    build:
+      context: shikimori
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
       EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE: http://discovery:8080/eureka/
@@ -60,12 +81,16 @@ services:
       recommendator:
         condition: service_healthy
   anilist:
+    image: lampirg/anilist:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: anilist
+    build:
+      context: anilist
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
       EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE: http://discovery:8080/eureka/
@@ -77,12 +102,16 @@ services:
       recommendator:
         condition: service_healthy
   frontend:
+    image: lampirg/frontend:0.0.1
     healthcheck:
       test: [ "CMD", "wget", "--no-verbose", "http://localhost:8080/actuator/health" ]
       interval: 10s
       timeout: 20s
       retries: 5
-    build: frontend
+    build:
+      context: frontend
+      additional_contexts:
+        animerecommendator-library: service:library
     environment:
       SERVER_PORT: 8080
       EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE: http://discovery:8080/eureka/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/frontend-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/frontend-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/frontend.jar /app/frontend.jar
+ENTRYPOINT ["java","-jar","/app/frontend.jar"]

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -69,6 +69,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>frontend</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/library/Dockerfile
+++ b/library/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:17-alpine AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+
+RUN ./mvnw dependency:resolve
+
+COPY src src
+
+RUN ./mvnw install -DskipTests

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -65,4 +65,8 @@
 
 	</dependencies>
 
+	<build>
+		<finalName>library</finalName>
+	</build>
+
 </project>

--- a/mal/Dockerfile
+++ b/mal/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/mal-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/mal-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/mal.jar /app/mal.jar
+ENTRYPOINT ["java","-jar","/app/mal.jar"]

--- a/mal/pom.xml
+++ b/mal/pom.xml
@@ -88,6 +88,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>mal</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/recommendator/Dockerfile
+++ b/recommendator/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/recommendator-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/recommendator-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/recommendator.jar /app/recommendator.jar
+ENTRYPOINT ["java","-jar","/app/recommendator.jar"]

--- a/recommendator/pom.xml
+++ b/recommendator/pom.xml
@@ -82,6 +82,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>recommendator</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/shikimori/Dockerfile
+++ b/shikimori/Dockerfile
@@ -1,4 +1,19 @@
+FROM eclipse-temurin:17 AS build
+
+WORKDIR /workspace/app
+
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+COPY --from=animerecommendator-library:latest /root/.m2 /root/.m2
+
+RUN ./mvnw -B -e org.apache.maven.plugins:maven-dependency-plugin:go-offline -DexcludeArtifactIds=library
+
+COPY src src
+
+RUN ./mvnw install -DskipTests
+
 FROM eclipse-temurin:17
-ARG JAR_FILE=target/*.jar
-COPY ./target/shikimori-0.0.1-SNAPSHOT.jar /app/
-CMD ["java", "-jar", "/app/shikimori-0.0.1-SNAPSHOT.jar"]
+ARG DEPENDENCY=/workspace/app/target
+COPY --from=build ${DEPENDENCY}/shikimori.jar /app/shikimori.jar
+ENTRYPOINT ["java","-jar","/app/shikimori.jar"]

--- a/shikimori/pom.xml
+++ b/shikimori/pom.xml
@@ -85,6 +85,7 @@
 	</dependencyManagement>
 
 	<build>
+		<finalName>shikimori</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This pull request introduces multi stage image building for application modules. It also makes Docker doable as application building mechanism as before you had to build jar files locally.


The greatest trouble (broke me 3 yeats ago) is that library module as isolated module can't be seen (since it is not public dependency) by other modules thus they can't build themselves.
The solution is build.additional_contexts in Docker Compose with library as separate image.
The solution has a few shortcomings: ugly COPY from /root/.m2 (probably can be fixed but im lazy) and library image starts as container (then immediately exits; maybe can be fixed but google haven't helped me).
The other (maybe more elegant) solution would be private Nexus repository with library as module. But to push library module there you still need to build its image so a little would be changed.